### PR TITLE
Allow users to separate start key from next key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ let g:multi_cursor_skip_key='<C-x>'
 let g:multi_cursor_quit_key='<Esc>'
 ```
 
+By default, the 'next' key is also used to enter multicursor mode. If you want to use a different key to start multicursor mode than for selecting the next location, do like the following:
+```
+" Map start key separately from next key
+let g:multi_cursor_start_key='<F6>'
+```
+
 **IMPORTANT:** Please note that currently only single keystrokes and special keys can be mapped. This contraint is also the reason why multikey commands such as `ciw` do not work and cause unexpected behavior in Normal mode. This means that a mapping like `<Leader>n` will NOT work correctly. For a list of special keys that are supported, see `help :key-notation`
 
 **NOTE:** Please make sure to always map something to `g:multi_cursor_quit_key`, otherwise you'll have a tough time quitting from multicursor mode.

--- a/doc/multiple_cursors.txt
+++ b/doc/multiple_cursors.txt
@@ -99,6 +99,15 @@ following: >
     let g:multi_cursor_quit_key='<Esc>'
 <
 
+*g:multi_cursor_start_key* (Default: 'g:multi_cursor_next_key')
+By default, the same key is used to enter multicursor mode as to select the
+next cursor location.  If you want to use a different key to start multicursor
+mode than for selecting the next location, do like the following: >
+
+    " Map start key separately from next key
+    let g:multi_cursor_start_key='<F6>'
+<
+
 IMPORTANT: Please note that currently only single keystroes and special
 keys can be mapped. This contraint is also the reason why multikey commands
 such as `ciw` do not work and cause unexpected behavior in Normal mode. This

--- a/plugin/multiple_cursors.vim
+++ b/plugin/multiple_cursors.vim
@@ -45,11 +45,15 @@ if g:multi_cursor_use_default_mapping
   call s:init_settings(s:settings_if_default)
 endif
 
+if !exists('g:multi_cursor_start_key') && exists('g:multi_cursor_next_key')
+  let g:multi_cursor_start_key = g:multi_cursor_next_key
+endif
+
 " External mappings
-if exists('g:multi_cursor_next_key')
-  exec 'nnoremap <silent> '.g:multi_cursor_next_key.
+if exists('g:multi_cursor_start_key')
+  exec 'nnoremap <silent> '.g:multi_cursor_start_key.
         \' :call multiple_cursors#new("n")<CR>'
-  exec 'xnoremap <silent> '.g:multi_cursor_next_key.
+  exec 'xnoremap <silent> '.g:multi_cursor_start_key.
         \' :<C-u>call multiple_cursors#new("v")<CR>'
 endif
 


### PR DESCRIPTION
This enables the use of ctrl-{n,p,x} while in multiselect mode, while not forcing the user to clobber his ctrl-n mapping in normal mode.
