### PR TITLE
Open folds around new cursors

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -238,6 +238,9 @@ function! s:Cursor.new(position)
   let obj.cursor_hi_id = s:highlight_cursor(a:position)
   let obj.visual_hi_id = 0
   let obj.line_length = col([a:position[0], '$'])
+  if has('folding')
+    silent! execute a:position[0] . "foldopen!"
+  endif
   return obj
 endfunction
 


### PR DESCRIPTION
If changes are made with a cursor inside of a closed fold, the entire
fold will be treated as if it was selected rather than just the matched
portion of it.  To avoid this open all folds around new cursors.
