### PR TITLE
Fix bug with async plugins

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -748,6 +748,10 @@ function! s:feedkeys(keys)
     if type(c) == 0 && c == 0
       break
     endif
+    " Discard KE_EVENT. Other plugins calling eval can cause this
+    if type(c) == 1 && c == "\x80\xfd\x63"
+      break
+    endif
   endwhile
   call feedkeys(a:keys)
 endfunction


### PR DESCRIPTION
Apparently getchar(0) will return KE_EVENT forever if a plugin is doing work in the background. Plugins that do this are rare, but hitting this really sucks for users. Also, these sorts of plugins will become more prevalent if Neovim grows in adoption.
