### PR TITLE
Add support for searching whole words

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ By default, the 'next' key is also used to enter multicursor mode. If you want t
 let g:multi_cursor_start_key='<F6>'
 ```
 
+Note that when multicursor mode is started, it selects current word without boundaries, i.e. it behavies like `g*`. If you want to use word boundaries in Normal mode (as `*` does) but still have old behaviour up your sleeve, you can do the following:
+```
+let g:multi_cursor_start_key='g<C-n>'
+let g:multi_cursor_start_word_key='<C-n>'
+```
+In this configuration `<C-n>` will start multicursor mode using word boundaries (but only in Normal mode, as it does not make much sense to use it in Visual mode). Old behaviour without word boundaries is still available using `g<C-n>`.
+
 **IMPORTANT:** Please note that currently only single keystrokes and special keys can be mapped. This means that a mapping like `<Leader>n` will NOT work correctly. For a list of special keys that are supported, see `help :key-notation`
 
 **NOTE:** Please make sure to always map something to `g:multi_cursor_quit_key`, otherwise you'll have a tough time quitting from multicursor mode.

--- a/doc/multiple_cursors.txt
+++ b/doc/multiple_cursors.txt
@@ -108,6 +108,21 @@ mode than for selecting the next location, do like the following: >
     let g:multi_cursor_start_key='<F6>'
 <
 
+*g:multi_cursor_start_word_key*
+When multicursor mode is started, it selects current word without
+boundaries, i.e. it behavies like `g*`. If you want to use word boundaries in
+Normal mode (as `*` does) but still have old behaviour up your sleeve, you can
+do the following: >
+
+    let g:multi_cursor_start_key='g<C-n>'
+    let g:multi_cursor_start_word_key='<C-n>'
+<
+
+In this configuration <C-n> will start multicursor mode using word boundaries
+(but only in Normal mode, as it does not make much sense to use it in Visual
+mode). Old behaviour without word boundaries is still available using
+g<C-n>.
+
 IMPORTANT: Please note that currently only single keystroes and special
 keys can be mapped. This contraint is also the reason why multikey commands
 such as `ciw` do not work and cause unexpected behavior in Normal mode. This

--- a/plugin/multiple_cursors.vim
+++ b/plugin/multiple_cursors.vim
@@ -56,9 +56,16 @@ endif
 " External mappings
 if exists('g:multi_cursor_start_key')
   exec 'nnoremap <silent> '.g:multi_cursor_start_key.
-        \' :call multiple_cursors#new("n")<CR>'
+        \' :call multiple_cursors#new("n", 0)<CR>'
   exec 'xnoremap <silent> '.g:multi_cursor_start_key.
-        \' :<C-u>call multiple_cursors#new("v")<CR>'
+        \' :<C-u>call multiple_cursors#new("v", 0)<CR>'
+endif
+
+if exists('g:multi_cursor_start_word_key')
+  exec 'nnoremap <silent> '.g:multi_cursor_start_word_key.
+        \' :call multiple_cursors#new("n", 1)<CR>'
+  exec 'xnoremap <silent> '.g:multi_cursor_start_word_key.
+        \' :<C-u>call multiple_cursors#new("v", 1)<CR>'
 endif
 
 " Commands

--- a/plugin/multiple_cursors.vim
+++ b/plugin/multiple_cursors.vim
@@ -64,8 +64,9 @@ endif
 if exists('g:multi_cursor_start_word_key')
   exec 'nnoremap <silent> '.g:multi_cursor_start_word_key.
         \' :call multiple_cursors#new("n", 1)<CR>'
+  " In Visual mode word boundary is not used
   exec 'xnoremap <silent> '.g:multi_cursor_start_word_key.
-        \' :<C-u>call multiple_cursors#new("v", 1)<CR>'
+        \' :<C-u>call multiple_cursors#new("v", 0)<CR>'
 endif
 
 " Commands


### PR DESCRIPTION
VIM's * command searches for the whole word -- it wraps current word with word
boundaries: \< and \>. g*, on the other hand, does not care about word
boundaries.

This patch adds functionality to configure multiple cursors behaviour to be
consistent with VIM's * and g*. To do that, use newly introduced option:

    let g:multi_cursor_start_key='g<C-n>'
    let g:multi_cursor_start_word_key='<C-n>'

Note that in current implementation "start word" command works in both Normal
and Visual modes.

Fixes #104.