### PR TITLE
Call Multiple_cursors_before with find

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -236,6 +236,14 @@ function! multiple_cursors#find(start, end, pattern)
     return
   else
     echohl Normal | echo 'Added '.s:cm.size().' cursor'.(s:cm.size()>1?'s':'') | echohl None
+
+    " If we've created any cursors, we need to call the before function, end
+    " function will be called via normal routes
+    if exists('*Multiple_cursors_before') && !s:before_function_called
+      exe "call Multiple_cursors_before()"
+      let s:before_function_called = 1
+    endif
+
     call s:wait_for_user_input('v')
   endif
 endfunction


### PR DESCRIPTION
This fixes a problem where if you use MultipleCursorFind, you don't get the _before function called

Wasn't sure how to write a test for this case, didn't look like the _before and _after functionality is tested in the specs.

I didn't see a CONTRIBUTING doc or anything, please let me know if there is anything I need to do to conform to this projects guidelines...