### PR TITLE
Fix a subtle bug in _normal_maps

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -993,7 +993,9 @@ endfunction
 
 let s:retry_keys = ""
 function! s:display_error()
-  if s:bad_input == s:cm.size() && has_key(g:multi_cursor_normal_maps, s:char[0])
+  if s:bad_input == s:cm.size()
+        \ && s:from_mode ==# 'n'
+        \ && has_key(g:multi_cursor_normal_maps, s:char[0])
     " we couldn't replay it anywhere but we're told it's the beginning of a
     " multi-character map like the `d` in `dw`
     let s:retry_keys = s:char
@@ -1045,13 +1047,13 @@ function! s:last_char()
 endfunction
 
 function! s:wait_for_user_input(mode)
+  call s:display_error()
+
   let s:from_mode = a:mode
   if empty(a:mode)
     let s:from_mode = s:to_mode
   endif
   let s:to_mode = ''
-
-  call s:display_error()
 
   " Right before redraw, apply the highlighting bug fix
   call s:apply_highlight_fix()


### PR DESCRIPTION
The check was not taking into account the mode, so values set in
g:multi_cursor_normal_maps were also (sort of) applying in visual mode.

Secondary change: call `s:display_error()` *before* resetting the cursor modes
or else the mode we check there now is wrong.

@faceleg @balta2ar as discussed tangentially in #111 