### PR TITLE
Fix #27: allow <Ctrl-c> to quit highlight mode. Document in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ In this configuration `<C-n>` will start multicursor mode using word boundaries 
 
 **NOTE:** Prior to version 1.3, the recommended way to map the keys is using the expression quote syntax in Vim, using something like `"\<C-n>"` or `"\<Esc>"` (see h: expr-quote). After 1.3, the recommended way is to use a raw string like above. If your key mappings don't appear to work, give the new syntax a try.
 
-You can also map your own keys to quit:
+You can also map your own keys to quit, if ``g:multi_cursor_quit_key`` won't work:
 
 ```
+let g:multi_cursor_quit_key='<C-c>'
 nnoremap <C-c> :call multiple_cursors#quit()<CR>
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ In this configuration `<C-n>` will start multicursor mode using word boundaries 
 
 **NOTE:** Prior to version 1.3, the recommended way to map the keys is using the expression quote syntax in Vim, using something like `"\<C-n>"` or `"\<Esc>"` (see h: expr-quote). After 1.3, the recommended way is to use a raw string like above. If your key mappings don't appear to work, give the new syntax a try.
 
+You can also map your own keys to quit:
+
+```
+nnoremap <C-c> :call multiple_cursors#quit()<CR>
+```
+
 ## Settings
 Currently there are four additional global settings one can tweak:
 

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -170,6 +170,11 @@ function! multiple_cursors#new(mode, word_boundary)
   endif
 endfunction
 
+" Quit out of multicursor mode, fixes #27.
+function! multiple_cursors#quit()
+  call s:exit()
+endfunction
+
 " Delete the current cursor. If there's no more cursors, stop the loop
 function! multiple_cursors#prev()
   call s:cm.delete_current()


### PR DESCRIPTION
If you use https://github.com/Shougo/neobundle.vim, you can test with:

```viml
NeoBundle 'tony/vim-multiple-cursors', { 'rev': 'quit-multiple-cursors' }
```

Map quitting:

```viml
let g:multi_cursor_quit_key='<C-c>'
nnoremap <C-c> :call multiple_cursors#quit()<CR>
```

Originally was named "allow s:quit for multiple-cursors to be called publicly". Apparently, this will get ``<C-c>`` to work only if ``<C-c>`` is mapped, but there seems to be more interconnections inside that get in the way.