### PR TITLE
Fix typo in help text.

### DIFF
--- a/doc/multiple_cursors.txt
+++ b/doc/multiple_cursors.txt
@@ -1,11 +1,11 @@
 *vim-multiple-cursors.txt* True Sublime Text multiple selection in Vim
 
-                    ____  _       __                                            
+                    ____  _       __
    ____ ___  __  __/ / /_(_)___  / /__     _______  ________________  __________
   / __ `__ \/ / / / / __/ / __ \/ / _ \   / ___/ / / / ___/ ___/ __ \/ ___/ ___/
- / / / / / / /_/ / / /_/ / /_/ / /  __/  / /__/ /_/ / /  (__  ) /_/ / /  (__  ) 
-/_/ /_/ /_/\__,_/_/\__/_/ .___/_/\___/   \___/\__,_/_/  /____/\____/_/  /____/  
-                       /_/                                                      
+ / / / / / / /_/ / / /_/ / /_/ / /  __/  / /__/ /_/ / /  (__  ) /_/ / /  (__  )
+/_/ /_/ /_/\__,_/_/\__/_/ .___/_/\___/   \___/\__,_/_/  /____/\____/_/  /____/
+                       /_/
 
 
                               Reference Manual~
@@ -71,7 +71,7 @@ CTRL-N in Normal mode and it will remove all prior cursors before starting a
 new one.
 
 ==============================================================================
-3. Mappings                                        *multiple-cursors-mappings* 
+3. Mappings                                        *multiple-cursors-mappings*
 
 *g:multi_cursor_use_default_mapping* (Default: 1)
 
@@ -123,7 +123,7 @@ In this configuration <C-n> will start multicursor mode using word boundaries
 mode). Old behaviour without word boundaries is still available using
 g<C-n>.
 
-IMPORTANT: Please note that currently only single keystroes and special
+IMPORTANT: Please note that currently only single keystrokes and special
 keys can be mapped. This contraint is also the reason why multikey commands
 such as `ciw` do not work and cause unexpected behavior in Normal mode. This
 means that a mapping like `<Leader>n` will NOT work correctly. For a list of
@@ -139,7 +139,7 @@ like above. If your key mappings don't appear to work, give the new syntax a
 try.
 
 ==============================================================================
-4. Global Options                            *multiple-cursors-global-options* 
+4. Global Options                            *multiple-cursors-global-options*
 
 Currently there are four additional global settings one can tweak:
 
@@ -190,7 +190,7 @@ like the following in your vimrc: >
 <
 
 ==============================================================================
-5. Issues                                            *multiple-cursors-issues* 
+5. Issues                                            *multiple-cursors-issues*
 
 - Multi key commands like ciw do not work at the moment
 - All user input typed before Vim is able to fan out the last operation to all
@@ -200,7 +200,7 @@ like the following in your vimrc: >
 - Select mode is not implemented
 
 ==============================================================================
-6. Contributing                                *multiple-cursors-contributing* 
+6. Contributing                                *multiple-cursors-contributing*
 
 The project is hosted on Github. Patches, feature requests and suggestions are
 always welcome!
@@ -209,19 +209,19 @@ Find the latest version of the plugin here:
     http://github.com/terryma/vim-multiple-cursors
 
 ==============================================================================
-7. License                                          *multiple-cursors-license* 
+7. License                                          *multiple-cursors-license*
 
 The project is licensed under the MIT license [7]. Copyrigth 2013 Terry Ma
 
 ==============================================================================
-8. Credit                                            *multiple-cursors-credit* 
+8. Credit                                            *multiple-cursors-credit*
 
 The plugin is obviously inspired by Sublime Text's awesome multiple selection
 [6] feature. Some inspiration was also taken from Emac's multiple cursors [8]
-implementation. 
+implementation.
 
 ==============================================================================
-9. References                                    *multiple-cursors-references* 
+9. References                                    *multiple-cursors-references*
 
 [1] https://github.com/paradigm/vim-multicursor
 [2] https://github.com/felixr/vim-multiedit


### PR DESCRIPTION
Fixed a typo ('keystroes' v 'keystrokes').

Apparently, also removed trailing whitespace as I forgot I have that setting on in Vim. If that's a problem, I can redo this PR.