### PR TITLE
Save the selection setting when CursorManager is created.

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -365,6 +365,7 @@ function! s:CursorManager.new()
         \ 'lazyredraw': &lazyredraw,
         \ 'paste': &paste,
         \ 'clipboard': &clipboard,
+        \ 'selection': &selection
         \ }
   " We save the window view when multicursor mode is entered
   let obj.saved_winview = []
@@ -587,6 +588,7 @@ function! s:CursorManager.initialize() dict
   let self.saved_settings['lazyredraw'] = &lazyredraw
   let self.saved_settings['paste'] = &paste
   let self.saved_settings['clipboard'] = &clipboard
+  let self.saved_settings['selection'] = &selection
   let &virtualedit = "onemore"
   let &cursorline = 0
   let &lazyredraw = 1
@@ -611,6 +613,7 @@ function! s:CursorManager.restore_user_settings() dict
     let &lazyredraw = self.saved_settings['lazyredraw']
     let &paste = self.saved_settings['paste']
     let &clipboard = self.saved_settings['clipboard']
+    let &selection = self.saved_settings['selection']
   endif
 
   " Restore original contents and type of unnamed register. This method is


### PR DESCRIPTION
This fixes the issue where if the `selection` setting was set to anything but `inclusive`, the plugin would no longer work.