### PR TITLE
Quick stab at selecting word boundaries by defualt

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install using [Pathogen], [Vundle], [Neobundle], or your favorite Vim package ma
 Requires vim 7.4 or later for full functionality.
 
 ## Quick Start
-Out of the box, all you need to know is a single key `Ctrl-n`. Pressing the key in Normal mode highlights the current word under the cursor in Visual mode and places a virtual cursor at the end of it. Pressing it again finds the next ocurrence and places another virtual cursor at the end of the visual selection. If you select multiple lines in Visual mode, pressing the key puts a virtual cursor at every line and leaves you in Normal mode.
+Out of the box, all you need to know is a single key `Ctrl-n`. Pressing the key in Normal mode highlights the current word under the cursor in Visual mode and places a virtual cursor at the end of it. Pressing it again finds the next occurrence and places another virtual cursor at the end of the visual selection. If you select multiple lines in Visual mode, pressing the key puts a virtual cursor at every line and leaves you in Normal mode.
 
 After you've marked all your locations with `Ctrl-n`, you can change the visual selection with normal Vim motion commands in Visual mode. You could go to Normal mode by pressing `v` and wield your motion commands there. Single key command to switch to Insert mode such as `c` or `s` from Visual mode or `i`, `a`, `I`, `A` in Normal mode should work without any issues.
 
@@ -85,12 +85,12 @@ By default, the 'next' key is also used to enter multicursor mode. If you want t
 let g:multi_cursor_start_key='<F6>'
 ```
 
-Note that when multicursor mode is started, it selects current word without boundaries, i.e. it behaves like `g*`. If you want to use word boundaries in Normal mode (as `*` does) but still have old behaviour up your sleeve, you can do the following:
+Note that when multicursor mode is started, it selects current word with boundaries, i.e. it behaves like `*`. If you want to avoid word boundaries in Normal mode (as `g*` does) but still have old behaviour up your sleeve, you can do the following:
 ```viml
-let g:multi_cursor_start_key='g<C-n>'
-let g:multi_cursor_start_word_key='<C-n>'
+let g:multi_cursor_start_key='<C-n>'
+let g:multi_cursor_start_word_key='g<C-n>'
 ```
-In this configuration `<C-n>` will start multicursor mode using word boundaries (but only in Normal mode, as it does not make much sense to use it in Visual mode). Old behaviour without word boundaries is still available using `g<C-n>`.
+In this configuration `<C-n>` will start multicursor mode without word boundaries (but only in Normal mode, as it does not make much sense to use it in Visual mode). Old behaviour with word boundaries is still available using `g<C-n>`.
 
 **IMPORTANT:** Please note that currently only single keystrokes and special keys can be mapped. This means that a mapping like `<Leader>n` will NOT work correctly. For a list of special keys that are supported, see `help :key-notation`
 

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -44,7 +44,7 @@ let s:before_function_called = 0
 
 " Used for searching whole words (search pattern is wrapped with \< and \>)
 " Keep old behaviour by default (act like g*)
-let s:use_word_boundary = 0
+let s:use_word_boundary = 1
 
 " Set up highlighting
 if !hlexists(s:hi_group_cursor)

--- a/plugin/multiple_cursors.vim
+++ b/plugin/multiple_cursors.vim
@@ -49,8 +49,8 @@ if g:multi_cursor_use_default_mapping
   call s:init_settings(s:settings_if_default)
 endif
 
-if !exists('g:multi_cursor_start_key') && exists('g:multi_cursor_next_key')
-  let g:multi_cursor_start_key = g:multi_cursor_next_key
+if !exists('g:multi_cursor_start_word_key') && exists('g:multi_cursor_next_key')
+  let g:multi_cursor_start_word_key = g:multi_cursor_next_key
 endif
 
 " External mappings
@@ -70,7 +70,7 @@ if exists('g:multi_cursor_start_word_key')
 endif
 
 " Commands
-command! -nargs=1 -range=% MultipleCursorsFind 
+command! -nargs=1 -range=% MultipleCursorsFind
       \ call multiple_cursors#find(<line1>, <line2>, <q-args>)
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
I got bit by this, and agree it should be default behaviour. Should fix #129 