### PR TITLE
Set good defaults for g:multi_cursor_normal_maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ beginning with the default leader key work in multi-cursor mode. You have to
 manually set this because vim doesn't provide a way to see which keys *start*
 mappings.
 
-### ```g:multi_cursor_normal_maps``` (Default: `{}`)
+### ```g:multi_cursor_normal_maps``` (Default: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`)
 Any key in this map (values are ignored) will cause multi-cursor _Normal_ mode
 to pause for map completion just like normal vim. Otherwise keys mapped in
 normal mode will "fail to replay" when multiple cursors are active. For example,

--- a/README.md
+++ b/README.md
@@ -120,19 +120,25 @@ to pause for `timeoutlen` waiting for map completion just like normal vim.
 Otherwise keys mapped in insert mode are ignored when multiple cursors are
 active. For example, setting it to `{'\':1}` will make insert-mode mappings
 beginning with the default leader key work in multi-cursor mode. You have to
-manually set this because vim doesn't provide a way to see which keys *start*
+manually set this because vim doesn't provide a way to see which keys _start_
 mappings.
 
 ### ```g:multi_cursor_normal_maps``` (Default: see below)
-Default value: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`
+Default value: `{'!':1, '@':1, '=':1, 'q':1, 'r':1, 't':1, 'T':1, 'y':1, '[':1, ']':1, '\':1, 'd':1, 'f':1, 'F':1, 'g':1, '"':1, 'z':1, 'c':1, 'm':1, '<':1, '>':1}`
 
 Any key in this map (values are ignored) will cause multi-cursor _Normal_ mode
 to pause for map completion just like normal vim. Otherwise keys mapped in
 normal mode will "fail to replay" when multiple cursors are active. For example,
-setting it to `{'d':1}` will make normal-mode mappings beginning with `d` (such
-as `dw` to delete a word) work in multi-cursor mode. You have to
-manually set this because vim doesn't provide a way to see which keys *start*
-mappings; setting it to include motion commands like `j` can break things.
+changing it from `{}` to `{'d':1}` makes normal-mode mappings beginning with `d`
+(such as `dw` to delete a word) work in multi-cursor mode.
+
+The default list contents should work for anybody, unless they have remapped a
+key from an operator-pending command to a non-operator-pending command or
+vice versa.
+
+These keys must be manually listed because vim doesn't provide a way to
+automatically see which keys _start_ mappings, and trying to run motion commands
+such as `j` as if they were operator-pending commands can break things.
 
 ### Interactions with other plugins
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ beginning with the default leader key work in multi-cursor mode. You have to
 manually set this because vim doesn't provide a way to see which keys *start*
 mappings.
 
-### ```g:multi_cursor_normal_maps``` (Default: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`)
+### ```g:multi_cursor_normal_maps``` (Default: see below)
 Any key in this map (values are ignored) will cause multi-cursor _Normal_ mode
 to pause for map completion just like normal vim. Otherwise keys mapped in
 normal mode will "fail to replay" when multiple cursors are active. For example,
@@ -131,6 +131,8 @@ setting it to `{'d':1}` will make normal-mode mappings beginning with `d` (such
 as `dw` to delete a word) work in multi-cursor mode. You have to
 manually set this because vim doesn't provide a way to see which keys *start*
 mappings; setting it to include motion commands like `j` can break things.
+
+Default value: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`
 
 ### Interactions with other plugins
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ manually set this because vim doesn't provide a way to see which keys *start*
 mappings.
 
 ### ```g:multi_cursor_normal_maps``` (Default: see below)
+Default value: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`
+
 Any key in this map (values are ignored) will cause multi-cursor _Normal_ mode
 to pause for map completion just like normal vim. Otherwise keys mapped in
 normal mode will "fail to replay" when multiple cursors are active. For example,
@@ -131,8 +133,6 @@ setting it to `{'d':1}` will make normal-mode mappings beginning with `d` (such
 as `dw` to delete a word) work in multi-cursor mode. You have to
 manually set this because vim doesn't provide a way to see which keys *start*
 mappings; setting it to include motion commands like `j` can break things.
-
-Default value: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`
 
 ### Interactions with other plugins
 

--- a/doc/multiple_cursors.txt
+++ b/doc/multiple_cursors.txt
@@ -167,7 +167,7 @@ beginning with the default leader key work in multi-cursor mode. You have to
 manually set this because vim doesn't provide a way to see which keys _start_
 mappings.
 
-*g:multi_cursor_normal_maps* (Default: `{}`)
+*g:multi_cursor_normal_maps* (Default: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`)
 
 Any key in this map (values are ignored) will cause multi-cursor _Normal_ mode
 to pause for map completion just like normal vim. Otherwise keys mapped in

--- a/doc/multiple_cursors.txt
+++ b/doc/multiple_cursors.txt
@@ -169,6 +169,8 @@ mappings.
 
 *g:multi_cursor_normal_maps* (Default: see below)
 
+Default value: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`
+
 Any key in this map (values are ignored) will cause multi-cursor _Normal_ mode
 to pause for map completion just like normal vim. Otherwise keys mapped in
 normal mode will "fail to replay" when multiple cursors are active. For example,
@@ -176,8 +178,6 @@ setting it to `{'d':1}` will make normal-mode mappings beginning with `d` (such
 as `dw` to delete a word) work in multi-cursor mode. You have to
 manually set this because vim doesn't provide a way to see which keys _start_
 mappings; setting it to include motion commands like `j` can break things.
-
-Default value: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`
 
 
 The plugin uses the highlight group `multiple_cursors_cursor` and

--- a/doc/multiple_cursors.txt
+++ b/doc/multiple_cursors.txt
@@ -167,7 +167,7 @@ beginning with the default leader key work in multi-cursor mode. You have to
 manually set this because vim doesn't provide a way to see which keys _start_
 mappings.
 
-*g:multi_cursor_normal_maps* (Default: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`)
+*g:multi_cursor_normal_maps* (Default: see below)
 
 Any key in this map (values are ignored) will cause multi-cursor _Normal_ mode
 to pause for map completion just like normal vim. Otherwise keys mapped in
@@ -176,6 +176,8 @@ setting it to `{'d':1}` will make normal-mode mappings beginning with `d` (such
 as `dw` to delete a word) work in multi-cursor mode. You have to
 manually set this because vim doesn't provide a way to see which keys _start_
 mappings; setting it to include motion commands like `j` can break things.
+
+Default value: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`
 
 
 The plugin uses the highlight group `multiple_cursors_cursor` and

--- a/doc/multiple_cursors.txt
+++ b/doc/multiple_cursors.txt
@@ -169,15 +169,21 @@ mappings.
 
 *g:multi_cursor_normal_maps* (Default: see below)
 
-Default value: `{'!':1,'@':1,'=':1,'q':1,'r':1,'t':1,'T':1,'y':1,'[':1,']':1,'\':1,'d':1,'f':1,'F':1,'g':1,'"':1,'z':1,'c':1,'m':1,'<':1,'>':1}`
+Default value: `{'!':1, '@':1, '=':1, 'q':1, 'r':1, 't':1, 'T':1, 'y':1, '[':1, ']':1, '\':1, 'd':1, 'f':1, 'F':1, 'g':1, '"':1, 'z':1, 'c':1, 'm':1, '<':1, '>':1}`
 
 Any key in this map (values are ignored) will cause multi-cursor _Normal_ mode
 to pause for map completion just like normal vim. Otherwise keys mapped in
 normal mode will "fail to replay" when multiple cursors are active. For example,
-setting it to `{'d':1}` will make normal-mode mappings beginning with `d` (such
-as `dw` to delete a word) work in multi-cursor mode. You have to
-manually set this because vim doesn't provide a way to see which keys _start_
-mappings; setting it to include motion commands like `j` can break things.
+changing it from `{}` to `{'d':1}` makes normal-mode mappings beginning with `d`
+(such as `dw` to delete a word) work in multi-cursor mode.
+
+The default list contents should work for anybody, unless they have remapped a
+key from an operator-pending command to a non-operator-pending command or
+vice versa.
+
+These keys must be manually listed because vim doesn't provide a way to
+automatically see which keys _start_ mappings, and trying to run motion commands
+such as `j` as if they were operator-pending commands can break things.
 
 
 The plugin uses the highlight group `multiple_cursors_cursor` and

--- a/plugin/multiple_cursors.vim
+++ b/plugin/multiple_cursors.vim
@@ -33,15 +33,20 @@ let s:settings = {
       \ 'debug_latency': 0,
       \ }
 
-let g:multi_cursor_insert_maps = get(g:, 'multi_cursor_insert_maps', {})
-let g:multi_cursor_normal_maps = get(g:, 'multi_cursor_normal_maps', {})
-
 let s:settings_if_default = {
       \ 'quit_key': '<Esc>',
       \ 'next_key': '<C-n>',
       \ 'prev_key': '<C-p>',
       \ 'skip_key': '<C-x>',
       \ }
+
+let s:default_insert_maps = {}
+let s:default_normal_maps = {'!':1, '@':1, '=':1, 'q':1, 'r':1, 't':1, 'T':1, 'y':1, '[':1, ']':1, '\':1, 'd':1, 'f':1, 'F':1, 'g':1, '"':1, 'z':1, 'c':1, 'm':1, '<':1, '>':1}
+
+let g:multi_cursor_insert_maps =
+      \ get(g:, 'multi_cursor_insert_maps', s:default_insert_maps)
+let g:multi_cursor_normal_maps =
+      \ get(g:, 'multi_cursor_normal_maps', s:default_normal_maps)
 
 call s:init_settings(s:settings)
 

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -32,9 +32,10 @@ end
 
 describe "Multiple Cursors op pending & exit from insert|visual mode" do
   let(:filename) { 'test.txt' }
-  let(:options) { ['let g:multi_cursor_normal_maps = {"d": 1, "c": 1}',
-                   'let g:multi_cursor_exit_from_insert_mode = 0',
+  let(:options) { ['let g:multi_cursor_exit_from_insert_mode = 0',
                    'let g:multi_cursor_exit_from_visual_mode = 0'] }
+  # the default value of g:multi_cursor_normal_maps already works
+  # for testing operator-pending
 
   specify "#paste from unnamed register to 3 cursors" do
     before <<-EOF
@@ -131,6 +132,32 @@ describe "Multiple Cursors op pending & exit from insert|visual mode" do
       hello 1jan world
       hello 1feb world
       hello 1mar world
+    EOF
+  end
+
+end
+
+describe "Multiple Cursors when normal_maps is empty" do
+  let(:filename) { 'test.txt' }
+  let(:options) { ['let g:multi_cursor_normal_maps = {}'] }
+
+  # Operator-pending commands are handled correctly thanks to their inclusion
+  # in `g:multi_cursor_normal_maps`.
+  #
+  # When an operator-pending command like 'd' is missing from that setting's
+  # value, then it should result in a no-op, but we should still remain in
+  # multicursor mode.
+  specify "#normal mode 'd'" do
+    before <<-EOF
+      hello
+      hello
+    EOF
+
+    type '<C-n><C-n>vdx<Esc>'
+
+    after <<-EOF
+      hell
+      hell
     EOF
   end
 
@@ -429,22 +456,6 @@ describe "Multiple Cursors" do
     after <<-EOF
       hello
       hello
-    EOF
-  end
-
-  # 'd' is an operator pending command, which are not supported at the moment.
-  # This should result in a nop, but we should still remain in multicursor mode.
-  specify "#normal mode 'd'" do
-    before <<-EOF
-      hello
-      hello
-    EOF
-
-    type '<C-n><C-n>vdx<Esc>'
-
-    after <<-EOF
-      hell
-      hell
     EOF
   end
 


### PR DESCRIPTION
I identified these multi-key mappings by going across the keyboard, row by row, and checking whether that key, or <kbd>Shift</kbd> plus that key, was a multi-key mapping by default.

I manually tested this change by removing the setting from my `vimrc` and making sure that the listed keys were still handled correctly, and that they weren’t when the dictionary was set to empty.

I first posted these values for `g:multi_cursor_normal_maps` in https://github.com/terryma/vim-multiple-cursors/issues/21#issuecomment-75443638.