### PR TITLE
Fixed failing test in benchmark_spec

### DIFF
--- a/spec/benchmark_spec.rb
+++ b/spec/benchmark_spec.rb
@@ -58,6 +58,7 @@ end
 
 describe "Multiple Cursors" do
   let(:filename) { 'test.txt' }
+  let(:options) { [] }
 
   specify "#benchmark" do
     before <<-EOF


### PR DESCRIPTION
Tests were failing because `spec/benchmark_spec.rb` was using a `before` method (defined in `spec/multiple_cursors_spec.rb`) which required `options` to be available to the context.

## Failed output

```
Multiple Cursors
  #benchmark (FAILED - 1)

Multiple Cursors op pending & exit from insert|visual mode
  #paste from unnamed register to 3 cursors
  #paste buffer normal caw then p
  #paste buffer normal C then ABC then p
  #paste buffer normal daw then P
  #paste buffer normal D then P
  #paste buffer normal s then p

Multiple Cursors when normal_maps is empty
  #normal mode 'd'

Multiple Cursors
  #paste buffer normal x then p
  #paste buffer visual y then p
  #paste buffer initial visual y then P
  #paste buffer visual y then P
  #paste buffer visual Y then P
  #multiline replacement
  #single line replacement
  #mixed line replacement
  #new line in insert mode
  #new line in insert mode middle of line
  #normal mode 'o'
  #normal mode 'O'
  #find command basic
  #visual line mode replacement
  #skip key
  #prev key
  #normal mode 'I'
  #normal mode 'A'
  #undo
  #multiline visual mode
  #set paste mode

Failures:

  1) Multiple Cursors #benchmark
     Failure/Error: before <<-EOF
     NameError:
       undefined local variable or method `options' for #<RSpec::Core::ExampleGroup::Nested_1:0x007fb1cc8b10c0>
     # ./spec/multiple_cursors_spec.rb:15:in `before'
     # ./spec/benchmark_spec.rb:63:in `block (2 levels) in <top (required)>'

Finished in 1 minute 14.44 seconds
29 examples, 1 failure

Failed examples:

rspec ./spec/benchmark_spec.rb:62 # Multiple Cursors #benchmark
```

## New output

```

Multiple Cursors
latency file = /var/folders/yy/8xt6qzt90n5gwd_6x69fr2n80000gn/T/vcRVY3O/0
  #benchmark

Multiple Cursors op pending & exit from insert|visual mode
  #paste from unnamed register to 3 cursors
  #paste buffer normal caw then p
  #paste buffer normal C then ABC then p
  #paste buffer normal daw then P
  #paste buffer normal D then P
  #paste buffer normal s then p

Multiple Cursors when normal_maps is empty
  #normal mode 'd'

Multiple Cursors
  #paste buffer normal x then p
  #paste buffer visual y then p
  #paste buffer initial visual y then P
  #paste buffer visual y then P
  #paste buffer visual Y then P
  #multiline replacement
  #single line replacement
  #mixed line replacement
  #new line in insert mode
  #new line in insert mode middle of line
  #normal mode 'o'
  #normal mode 'O'
  #find command basic
  #visual line mode replacement
  #skip key
  #prev key
  #normal mode 'I'
  #normal mode 'A'
  #undo
  #multiline visual mode
  #set paste mode

Finished in 1 minute 46.14 seconds
```