### PR TITLE
Fix #55: make I and A work in Visual mode

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -409,9 +409,11 @@ function! s:CursorManager.reset(restore_view, restore_setting, ...) dict
   let self.cursors = []
   let self.current_index = -1
   let self.starting_index = -1
+  let self.saved_positions = []
   let self.saved_winview = []
   let self.start_from_find = 0
   let s:char = ''
+  let s:saved_char = ''
   if a:restore_setting
     call self.restore_user_settings()
   endif

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1143,7 +1143,7 @@ function! s:wait_for_user_input(mode)
   let s:char = s:retry_keys . s:saved_keys
   if len(s:saved_keys) == 0
     let s:char .= s:get_char()
-    if a:mode ==# 'v' && s:char =~# 'I\|A'
+    if s:char =~# 'I\|A' && s:from_mode ==# 'v'
       if s:char ==# 'I'
         let s:saved_positions = []
         call s:cm.start_loop()

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -931,6 +931,14 @@ function! s:apply_user_input_next(mode)
       call s:update_visual_markers(s:cm.get_current().visual)
     endif
     call feedkeys("\<Plug>(multiple-cursors-wait)")
+    if exists('s:saved_char') && s:char ==# 'v' && s:to_mode ==# 'n'
+      if s:saved_char ==# 'I'
+        call feedkeys('bi')
+      elseif s:saved_char ==# 'A'
+        call feedkeys('a')
+      endif
+      unlet s:saved_char
+    endif
   else
     " Continue to next
     call feedkeys("\<Plug>(multiple-cursors-input)")
@@ -1124,6 +1132,10 @@ function! s:wait_for_user_input(mode)
   let s:char = s:retry_keys . s:saved_keys
   if len(s:saved_keys) == 0
     let s:char .= s:get_char()
+    if a:mode ==# 'v' && s:char =~# 'I\|A'
+      let s:saved_char = s:char
+      let s:char = 'v'
+    endif
   else
     let s:saved_keys = ""
   endif

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -933,7 +933,18 @@ function! s:apply_user_input_next(mode)
     call feedkeys("\<Plug>(multiple-cursors-wait)")
     if exists('s:saved_char') && s:char ==# 'v' && s:to_mode ==# 'n'
       if s:saved_char ==# 'I'
-        call feedkeys('bi')
+        call s:cm.start_loop()
+        let pos = remove(s:saved_positions, 0)
+        call s:cm.get_current().update_position(pos)
+        call cursor(pos)
+        call s:cm.next()
+        while !s:cm.loop_done()
+          let pos = remove(s:saved_positions, 0)
+          call s:cm.get_current().update_position(pos)
+          call cursor(pos)
+          call s:cm.next()
+        endwhile
+        call feedkeys('i')
       elseif s:saved_char ==# 'A'
         call feedkeys('a')
       endif
@@ -1133,6 +1144,16 @@ function! s:wait_for_user_input(mode)
   if len(s:saved_keys) == 0
     let s:char .= s:get_char()
     if a:mode ==# 'v' && s:char =~# 'I\|A'
+      if s:char ==# 'I'
+        let s:saved_positions = []
+        call s:cm.start_loop()
+        call add(s:saved_positions, s:cm.get_current().visual[0])
+        call s:cm.next()
+        while !s:cm.loop_done()
+          call add(s:saved_positions, s:cm.get_current().visual[0])
+          call s:cm.next()
+        endwhile
+      endif
       let s:saved_char = s:char
       let s:char = 'v'
     endif

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -449,6 +449,38 @@ describe "Multiple Cursors" do
     EOF
   end
 
+  specify "#resize regions visual mode 'I'" do
+    before <<-EOF
+      hello world jan
+      hello world feb
+      hello world mar
+    EOF
+
+    type 'w<C-n><C-n><C-n>hhhIbefore<Esc>'
+
+    after <<-EOF
+      hello beforeworld jan
+      hello beforeworld feb
+      hello beforeworld mar
+    EOF
+  end
+
+  specify "#resize regions visual mode 'A'" do
+    before <<-EOF
+      hello world jan
+      hello world feb
+      hello world mar
+    EOF
+
+    type 'w<C-n><C-n><C-n>hhhAbefore<Esc>'
+
+    after <<-EOF
+      hello wobeforerld jan
+      hello wobeforerld feb
+      hello wobeforerld mar
+    EOF
+  end
+
   specify "#no word boundries visual mode 'I'" do
     before <<-EOF
       hello hibye world
@@ -468,18 +500,18 @@ describe "Multiple Cursors" do
 
   specify "#variable-length regions visual mode 'I'" do
     before <<-EOF
-      hello foo world
-      hello foooo world
-      hello foooooo world
+      hello hii world
+      hello hiiii world
+      hello hiiiiii world
     EOF
 
-    vim.normal ':MultipleCursorsFind \<fo*\><CR>'
+    vim.normal ':MultipleCursorsFind \<hi*\><CR>'
     type 'Ibefore<Esc>'
 
     after <<-EOF
-      hello beforefoo world
-      hello beforefoooo world
-      hello beforefoooooo world
+      hello beforehii world
+      hello beforehiiii world
+      hello beforehiiiiii world
     EOF
   end
 

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -449,6 +449,40 @@ describe "Multiple Cursors" do
     EOF
   end
 
+  specify "#no word boundries visual mode 'I'" do
+    before <<-EOF
+      hello hibye world
+      hello hibye world
+      hello hibye world
+    EOF
+
+    vim.normal ':MultipleCursorsFind bye<CR>'
+    type 'Ibefore<Esc>'
+
+    after <<-EOF
+      hello hibeforebye world
+      hello hibeforebye world
+      hello hibeforebye world
+    EOF
+  end
+
+  specify "#variable-length regions visual mode 'I'" do
+    before <<-EOF
+      hello foo world
+      hello foooo world
+      hello foooooo world
+    EOF
+
+    vim.normal ':MultipleCursorsFind \<fo*\><CR>'
+    type 'Ibefore<Esc>'
+
+    after <<-EOF
+      hello beforefoo world
+      hello beforefoooo world
+      hello beforefoooooo world
+    EOF
+  end
+
   specify "#normal mode 'I'" do
     before <<-EOF
       hello

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -417,6 +417,38 @@ describe "Multiple Cursors" do
     EOF
   end
 
+  specify "#visual mode 'I'" do
+    before <<-EOF
+      hello world jan
+      hello world feb
+      hello world mar
+    EOF
+
+    type 'w<C-n><C-n><C-n>Ibefore<Esc>'
+
+    after <<-EOF
+      hello beforeworld jan
+      hello beforeworld feb
+      hello beforeworld mar
+    EOF
+  end
+
+  specify "#visual mode 'A'" do
+    before <<-EOF
+      hello world jan
+      hello world feb
+      hello world mar
+    EOF
+
+    type 'w<C-n><C-n><C-n>Aafter<Esc>'
+
+    after <<-EOF
+      hello worldafter jan
+      hello worldafter feb
+      hello worldafter mar
+    EOF
+  end
+
   specify "#normal mode 'I'" do
     before <<-EOF
       hello


### PR DESCRIPTION
Here's a potential fix for issue #55.

A more general solution might be possible by changing the `<Plug>(multiple-cursors-apply)` mappings to expression mappings and having `apply_user_input_next()` return an empty string - trying to resolve the issue of text being inserted into the buffer when `I` and `A` are pressed in Visual mode.

```VimL
inoremap <expr> <Plug>(multiple-cursors-apply) <SID>apply_user_input_next('i')
nnoremap <expr> <Plug>(multiple-cursors-apply) <SID>apply_user_input_next('n')
xnoremap <expr> <Plug>(multiple-cursors-apply) <SID>apply_user_input_next('v')
```