### PR TITLE
Keep cursor within range for MultipleCursorsFind

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -231,6 +231,10 @@ function! multiple_cursors#find(start, end, pattern)
     call search(a:pattern, 'ceW')
     let right = s:pos('.')
     if s:compare_pos(right, pos2) > 0
+      " Position the cursor at the end of the previous match so it'll be on a
+      " virtual cursor when multicursor mode is started. The `winrestview()`
+      " call below 'undoes' unnecessary repositionings
+      call search(a:pattern, 'be')
       break
     endif
     call s:cm.add(right, [left, right])


### PR DESCRIPTION
With the below buffer contents, when you visually select lines 2-5 and execute `:'<,'>MultipleCursorFind text_to_find`, the real cursor will be positioned on line 8 (outside the search range) - if line 8 is moved down a few pages (outside the view of lines 2-5), then all virtual cursors will be off-screen.

```
" visually select the next four lines and execute `:'<,'>MultipleCursorFind text_to_find`
text_to_find
text_to_find
text_to_find
text_to_find

" the cursor will be positioned on the following line
text_to_find
```

This PR fixes the issue by repositioning the real cursor at the end of the previous match when it goes outside the search range.