### PR TITLE
Updated readme to reflect default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Vim command sequence: `2Gfp<C-n><C-n><C-n>cname`
 ### Add a cursor to each line of your visual selection
 ![Example2](assets/example2.gif?raw=true)
 
-Vim command sequence: `2Gvip<C-n>i"<Right><Right><Right>",<Esc>vipJ$r]Idays = [`
+Vim command sequence: `2Gvip<C-n>i"<Right><Right><Right>",<Esc>vipgJ$r]Idays = [`
 
 ### Do it backwards too! This is not just a replay of the above gif :)
 ![Example3](assets/example3.gif?raw=true)


### PR DESCRIPTION
This is a keyboard fix for the second demo:

![Example2](/terryma/vim-multiple-cursors/blob/51d0717f63cc231f11b4b63ee5b611f589dce1b3/assets/example2.gif?raw=true)

Join (`J`) adds spaces between the letters by default. To accomplish this without spaces, you need to use `gJ`. Perhaps you have changed some settings or key combinations?

``` shell
J                       Join [count] lines, with a minimum of two lines.                             
                        Remove the indent and insert up to two spaces (see                           
                        below).  Fails when on the last line of the buffer.                          
                        If [count] is too big it is reduce to the number of                          
                        lines available.                                                             

                                                        v_J                                          
{Visual}J               Join the highlighted lines, with a minimum of two                            
                        lines.  Remove the indent and insert up to two spaces                        
                        (see below).  {not in Vi}                                                    

                                                        gJ                                           
gJ                      Join [count] lines, with a minimum of two lines.                             
                        Don't insert or remove any spaces.  {not in Vi}                              

                                                        v_gJ                                         
{Visual}gJ              Join the highlighted lines, with a minimum of two                            
                        lines.  Don't insert or remove any spaces.  {not in                          
                        Vi}                                                  
```

Source: `:help J`
