### PR TITLE
fix issue that vim-multiple-cursor break multi-byte strings

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1014,13 +1014,28 @@ function! s:get_visual_region(pos)
   return region
 endfunction
 
+function! s:strpart(s, i, l)
+  if a:l == 0
+    return ''
+  endif
+  let [s, l] = ['', 0]
+  for c in split(a:s, '\zs')
+    let s .= c
+    let l += len(c)
+    if l >= a:l
+      break
+    endif
+  endfor
+  return s
+endfunction
+
 " Return the content of the buffer between the input region. This is used to
 " find the next match in the buffer
 " Mode change: Normal -> Normal
 " Cursor change: None
 function! s:get_text(region)
   let lines = getline(a:region[0][0], a:region[1][0])
-  let lines[-1] = lines[-1][:a:region[1][1] - 1]
+  let lines[-1] = s:strpart(lines[-1], 0, a:region[1][1])
   let lines[0] = lines[0][a:region[0][1] - 1:]
   return join(lines, "\n")
 endfunction

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1019,7 +1019,7 @@ function! s:strpart(s, i, l)
     return ''
   endif
   let [s, l] = ['', 0]
-  for c in split(a:s, '\zs')
+  for c in split(a:s[a:i :], '\zs')
     let s .= c
     let l += len(c)
     if l >= a:l

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*- 
 require 'spec_helper'
 
 def set_file_content(string)

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -797,4 +797,20 @@ describe "Multiple Cursors" do
     EOF
   end
 
+  specify "#multi-byte strings" do
+    before <<-EOF
+      こんにちわビム
+      世界の中心でビムを叫ぶ
+      ビム大好き
+    EOF
+
+    type '/ビム<CR><C-n><C-n><C-n>cヴィム<ESC>'
+
+    after <<-EOF
+      こんにちわヴィム
+      世界の中心でヴィムを叫ぶ
+      ヴィム大好き
+    EOF
+  end
+
 end


### PR DESCRIPTION
s:get_text doesn't handle multi-byte strings.

before 

![terminal](https://user-images.githubusercontent.com/10111/28774490-9a8956da-7628-11e7-9775-e7283361eacf.gif)

after 

![terminal1](https://user-images.githubusercontent.com/10111/28774492-a06ea366-7628-11e7-95e2-c3d7faf13c8c.gif)
