### PR TITLE
Fix cursors update when number of lines changes

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -598,7 +598,8 @@ endfunction
 
 " Start tracking cursor updates
 function! s:CursorManager.start_loop() dict
-  let self.starting_index = self.current_index
+  let self.current_index  = 0
+  let self.starting_index = 0
 endfunction
 
 " Returns true if we're cycled through all the cursors

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -527,7 +527,7 @@ function! s:CursorManager.update_current() dict
     call cur.save_unnamed_register()
 
     call cur.remove_visual_selection()
-  elseif s:from_mode ==# 'i' && s:to_mode ==# 'n' && self.current_index != self.size() - 1
+  elseif s:from_mode ==# 'i' && s:to_mode ==# 'n' && self.current_index != 0
     normal! h
   elseif s:from_mode ==# 'n'
     " Save contents of unnamed register after each operation in Normal mode.


### PR DESCRIPTION
Updates where starting at index=size-1 and wrapping instead of starting at index=0

Then inserting cursors here and doing **backspace**:
```
|mon
|tue
|wed
```
You would loose the last cursor because cursor update was done in the order index=2, 0, 1 (see **s:CursorManager.update_current()**):
```
|mon|tuewed
```

This PR fixes it by updating cursors in the order index=0, 1, 2:
```
|mon|tue|wed
```

I did not notice any regression. It might fix #234: I observed a different behavior, but the issue description is a bit messy, so it is hard to see if it fixes the issue.

Please note that putting the cursor at the **end of the line** and pressing **del** is still flaky.
Nothing to do with my PR as it was already the case before, but I will try to tackle that when I have time.

Cheers,
Antoine