### PR TITLE
Fix <DEL> at End-Of-Line, add corresponding test

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -516,7 +516,6 @@ function! s:CursorManager.update_current() dict
     if s:to_mode ==# 'V'
       exec "normal! gvv\<Esc>"
     endif
-
     " Sets the cursor at the right place
     exec "normal! gv\<Esc>"
     call cur.update_visual_selection(s:get_visual_region(s:pos('.')))
@@ -525,7 +524,6 @@ function! s:CursorManager.update_current() dict
     " This should be executed after user input is processed, when unnamed
     " register already contains the text.
     call cur.save_unnamed_register()
-
     call cur.remove_visual_selection()
   elseif s:from_mode ==# 'i' && s:to_mode ==# 'n' && self.current_index != 0
     normal! h
@@ -533,9 +531,11 @@ function! s:CursorManager.update_current() dict
     " Save contents of unnamed register after each operation in Normal mode.
     call cur.save_unnamed_register()
   endif
-  let vdelta = line('$') - s:saved_linecount
+  let pos = s:pos('.')
+
   " If the total number of lines changed in the buffer, we need to potentially
   " adjust other cursor locations
+  let vdelta = line('$') - s:saved_linecount
   if vdelta != 0
     if self.current_index != self.size() - 1
       let cur_column_offset = (cur.column() - col('.')) * -1
@@ -547,7 +547,7 @@ function! s:CursorManager.update_current() dict
         let c = self.get(i)
         " If there're other cursors on the same line, we need to adjust their
         " columns. This needs to happen before we adjust their line!
-        if cur.line() == c.line()
+        if cur.line() == c.line() || cur.position == pos
           if vdelta > 0
             " Added a line
             let hdelta = cur_column_offset
@@ -583,7 +583,6 @@ function! s:CursorManager.update_current() dict
     endif
   endif
 
-  let pos = s:pos('.')
   if cur.position == pos
     return 0
   endif

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -190,7 +190,33 @@ describe "Multiple Cursors when visual_maps is empty" do
 
 end
 
-describe "Multiple Cursors" do
+describe "Multiple Cursors when changing the line count" do
+  let(:filename) { 'test.txt' }
+  let(:options) { ['set backspace=indent,eol,start'] }
+
+  specify "#backspace on first char of the line, then carriage return" do
+    before <<-EOF
+      madec
+      
+      antoine
+      joseph
+      andre
+    EOF
+
+    type 'Gvip<C-n>i<BS><cr>'
+
+    after <<-EOF
+      madec
+      
+      antoine
+      joseph
+      andre
+    EOF
+  end
+
+end
+
+describe "Multiple Cursors misc" do
   let(:filename) { 'test.txt' }
   let(:options) { ['set autoindent'] }
 

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*- 
+# -*- encoding: utf-8 -*-
 require 'spec_helper'
 
 def set_file_content(string)
@@ -197,19 +197,39 @@ describe "Multiple Cursors when changing the line count" do
   specify "#backspace on first char of the line, then carriage return" do
     before <<-EOF
       madec
-      
+
       antoine
-      joseph
       andre
+      joseph
     EOF
 
     type 'Gvip<C-n>i<BS><cr>'
 
     after <<-EOF
       madec
-      
+
+      antoine
+      andre
+      joseph
+    EOF
+  end
+
+  specify "#del at EOL, then carriage return" do
+    before <<-EOF
+      madec
       antoine
       joseph
+
+      andre
+    EOF
+
+    type 'vip<C-n>A<DEL><cr>'
+
+    after <<-EOF
+      madec
+      antoine
+      joseph
+
       andre
     EOF
   end


### PR DESCRIPTION
We can now press Del in insert mode at EOL, which is a nice feature.
Changes in the original code were very superficial to make it work.

All tests pass on antoinemadec/vim-multiple-cursors del_eof's branch.

Cheers,
Antoine