### PR TITLE
Add '0' key support in normal mode

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1230,8 +1230,16 @@ function! s:wait_for_user_input(mode)
     call feedkeys(s:char)
     call s:cm.reset(1, 1)
     return
-  elseif s:from_mode ==# 'n'
+  elseif s:from_mode ==# 'n' || s:from_mode =~# 'v\|V'
     while match(s:last_char(), "\\d") == 0
+      if match(s:char, '\(^\|\a\)0') == 0
+        " fixes an edge case concerning the `0` key.
+        " The 0 key behaves differently from [1-9].
+        " It's consumed immediately when it is the
+        " first key typed while we're waiting for input.
+        " References: issue #152, pull #241
+        break
+      endif
       let s:char .= s:get_char()
     endwhile
   endif

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -136,6 +136,38 @@ describe "Multiple Cursors op pending & exit from insert|visual mode" do
     EOF
   end
 
+  specify "#normal mode '0': goes to 1st char of line" do
+    before <<-EOF
+      hello jan world
+      hello feb world
+      hello mar world
+    EOF
+
+    type '<C-n><C-n><C-n>vw0dw<Esc><Esc>'
+
+    after <<-EOF
+      jan world
+      feb world
+      mar world
+    EOF
+  end
+
+  specify "#normal mode 'd0': deletes backward to 1st char of line" do
+    before <<-EOF
+      hello jan world
+      hello feb world
+      hello mar world
+    EOF
+
+    type '<C-n><C-n><C-n>vwd0<Esc><Esc>'
+
+    after <<-EOF
+      jan world
+      feb world
+      mar world
+    EOF
+  end
+
 end
 
 describe "Multiple Cursors when normal_maps is empty" do


### PR DESCRIPTION
Use ninrod's #207 PR and add:

- support for '\<command\>0' (e.g.: 'd0')
- tests checking '0' key is properly handled

*bundle exec rake* is passing.
Once merged, this closes #207 and #152 

Cheers,
Antoine