### PR TITLE
Insert mapping: fix {rhs}=<Esc> mappings; add 2+ chars {lhs} support

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1211,20 +1211,26 @@ function! s:wait_for_user_input(mode)
   endif
 
   if s:from_mode ==# 'i' && has_key(g:multi_cursor_insert_maps, s:last_char())
-    let c = getchar(0)
-    let char_type = type(c)
     let poll_count = 0
-    while char_type == 0 && c == 0 && poll_count < &timeoutlen
-      sleep 1m
+    let char_mapping = ""
+    while poll_count < &timeoutlen
       let c = getchar(0)
       let char_type = type(c)
       let poll_count += 1
+      if char_type == 0 && c != 0
+        let s:char .= nr2char(c)
+      elseif char_type == 1 " char with more than 8 bits (as string)
+        let s:char .= c
+      endif
+      let char_mapping = maparg(s:char, "i")
+      if char_mapping != ""
+        break
+      endif
+      sleep 1m
     endwhile
-
-    if char_type == 0 && c != 0
-      let s:char .= nr2char(c)
-    elseif char_type == 1 " char with more than 8 bits (as string)
-      let s:char .= c
+    if char_mapping != ""
+      " handle case where mapping is <esc>
+      exec 'let s:char = "\'.char_mapping.'"'
     endif
   elseif s:from_mode !=# 'i' && s:char[0] ==# ":"
     call feedkeys(s:char)

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1224,14 +1224,12 @@ function! s:wait_for_user_input(mode)
       endif
       let char_mapping = maparg(s:char, "i")
       if char_mapping != ""
+        " handle case where mapping is <esc>
+        exec 'let s:char = "\'.char_mapping.'"'
         break
       endif
       sleep 1m
     endwhile
-    if char_mapping != ""
-      " handle case where mapping is <esc>
-      exec 'let s:char = "\'.char_mapping.'"'
-    endif
   elseif s:from_mode !=# 'i' && s:char[0] ==# ":"
     call feedkeys(s:char)
     call s:cm.reset(1, 1)

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -170,6 +170,47 @@ describe "Multiple Cursors op pending & exit from insert|visual mode" do
 
 end
 
+describe "Multiple Cursors when using insert mapings" do
+  let(:filename) { 'test.txt' }
+  let(:options) { ['imap jj <esc>', 'imap jojo dude', 'let g:multi_cursor_insert_maps = { "j": 1 }' ] }
+  specify "#mapping doing <Esc>" do
+    before <<-EOF
+      hello world!
+      hello world!
+      bla bla bla
+      bla bla bla
+    EOF
+
+    type 'w<C-n><C-n>cjjidude<Esc>'
+
+    after <<-EOF
+      hello dude!
+      hello !
+      bla bla bla
+      bla bla bla
+    EOF
+  end
+
+  specify "#mapping using more than 2 characters" do
+    before <<-EOF
+      hello
+      hello
+      bla bla bla
+      bla bla bla
+    EOF
+
+    type '<C-n><C-n>A jojo<Esc>'
+
+    after <<-EOF
+      hello dude
+      hello dude
+      bla bla bla
+      bla bla bla
+    EOF
+  end
+
+end
+
 describe "Multiple Cursors when normal_maps is empty" do
   let(:filename) { 'test.txt' }
   let(:options) { ['let g:multi_cursor_normal_maps = {}'] }


### PR DESCRIPTION
Fixes #201 and #205 
Add support for 2+ chars {lhs} mapping as well.
E.g.:
`imap jan january`

Tests checking those features have been added.
*bundle exec rake* is passing.

Cheers,
Antoine