### PR TITLE
Feature: remove g:multi_cursor_insert_maps as it is not needed anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ To see what keystrokes are used for the above examples, see [the wiki page](http
 - Live update in Insert mode
 - One key to rule it all! See [Quick Start](#quick-start) on what the key does in different scenarios
 - Works in Normal, Insert, and Visual mode for any commands (including
-  multi-key commands, assuming you set `g:multicursor_insert_maps` and
-  `g:multicursor_normal_maps`; see Settings below for details)
+  multi-key commands, assuming you set `g:multicursor_normal_maps`;
+  see Settings below for details)
 
 ## Installation
 Install using [Pathogen], [Vundle], [Neobundle], or your favorite Vim package manager.
@@ -122,15 +122,6 @@ If set to 0, then pressing `g:multi_cursor_quit_key` in _Visual_ mode will not q
 
 ### ```g:multi_cursor_exit_from_insert_mode``` (Default: 1)
 If set to 0, then pressing `g:multi_cursor_quit_key` in _Insert_ mode will not quit and delete all existing cursors. This is useful if you want to press Escape and go back to Normal mode, and still be able to operate on all the cursors.
-
-### ```g:multi_cursor_insert_maps``` (Default: `{}`)
-Any key in this map (values are ignored) will cause multi-cursor _Insert_ mode
-to pause for `timeoutlen` waiting for map completion just like normal vim.
-Otherwise keys mapped in insert mode are ignored when multiple cursors are
-active. For example, setting it to `{'\':1}` will make insert-mode mappings
-beginning with the default leader key work in multi-cursor mode. You have to
-manually set this because vim doesn't provide a way to see which keys _start_
-mappings.
 
 ### ```g:multi_cursor_normal_maps``` (Default: see below)
 Default value: `{'!':1, '@':1, '=':1, 'q':1, 'r':1, 't':1, 'T':1, 'y':1, '[':1, ']':1, '\':1, 'd':1, 'f':1, 'F':1, 'g':1, '"':1, 'z':1, 'c':1, 'm':1, '<':1, '>':1}`

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1210,7 +1210,11 @@ function! s:wait_for_user_input(mode)
     let s:saved_keys = ""
   endif
 
-  if s:from_mode ==# 'i' && has_key(g:multi_cursor_insert_maps, s:last_char())
+  " ambiguous mappings are note supported; e.g.:
+  "   imap jj JJ
+  "   imap jjj JJJ
+  " will always trigger the 'jj' mapping
+  if s:from_mode ==# 'i' && mapcheck(s:char, "i") != ""
     let poll_count = 0
     let char_mapping = ""
     while poll_count < &timeoutlen

--- a/doc/multiple_cursors.txt
+++ b/doc/multiple_cursors.txt
@@ -157,16 +157,6 @@ quit and delete all existing cursors. This is useful if you want to press
 Escape and go back to Normal mode, and still be able to operate on all the
 cursors.
 
-*g:multi_cursor_insert_maps* (Default: `{}`)
-
-Any key in this map (values are ignored) will cause multi-cursor _Insert_ mode
-to pause for `timeoutlen` waiting for map completion just like normal vim.
-Otherwise keys mapped in insert mode are ignored when multiple cursors are
-active. For example, setting it to `{'\':1}` will make insert-mode mappings
-beginning with the default leader key work in multi-cursor mode. You have to
-manually set this because vim doesn't provide a way to see which keys _start_
-mappings.
-
 *g:multi_cursor_normal_maps* (Default: see below)
 
 Default value: `{'!':1, '@':1, '=':1, 'q':1, 'r':1, 't':1, 'T':1, 'y':1, '[':1, ']':1, '\':1, 'd':1, 'f':1, 'F':1, 'g':1, '"':1, 'z':1, 'c':1, 'm':1, '<':1, '>':1}`

--- a/plugin/multiple_cursors.vim
+++ b/plugin/multiple_cursors.vim
@@ -40,12 +40,9 @@ let s:settings_if_default = {
       \ 'skip_key': '<C-x>',
       \ }
 
-let s:default_insert_maps = {}
 let s:default_normal_maps = {'!':1, '@':1, '=':1, 'q':1, 'r':1, 't':1, 'T':1, 'y':1, '[':1, ']':1, '\':1, 'd':1, 'f':1, 'F':1, 'g':1, '"':1, 'z':1, 'c':1, 'm':1, '<':1, '>':1}
 let s:default_visual_maps = {'i':1, 'a':1, 'f':1, 'F':1, 't':1, 'T':1}
 
-let g:multi_cursor_insert_maps =
-      \ get(g:, 'multi_cursor_insert_maps', s:default_insert_maps)
 let g:multi_cursor_normal_maps =
       \ get(g:, 'multi_cursor_normal_maps', s:default_normal_maps)
 let g:multi_cursor_visual_maps =

--- a/spec/multiple_cursors_spec.rb
+++ b/spec/multiple_cursors_spec.rb
@@ -172,7 +172,7 @@ end
 
 describe "Multiple Cursors when using insert mapings" do
   let(:filename) { 'test.txt' }
-  let(:options) { ['imap jj <esc>', 'imap jojo dude', 'let g:multi_cursor_insert_maps = { "j": 1 }' ] }
+  let(:options) { ['imap jj <esc>', 'imap jojo dude'] }
   specify "#mapping doing <Esc>" do
     before <<-EOF
       hello world!


### PR DESCRIPTION
No need to add the first letter of your mappings in the ```g:multi_cursor_insert_maps``` variable anymore!
That means less manual steps and more fun for the user, thanks for the suggestion ;)

The handling of normal_maps and visual_maps seems to be trickier, so I did not touch it.
From what I understand their _maps variables not only can be used by the user, but also features default characters to be able to handle 'dw' kind of operation.

If you want to refactor them as well or if you have any suggestions for me, please do not hesitate.

*bundle exec rake* is passing.

Cheers,
Antoine