### PR TITLE
insert mapping loop was too long; handle multiple keywords in imap's

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1227,7 +1227,8 @@ function! s:wait_for_user_input(mode)
         let s:char .= c
       endif
       let char_mapping = maparg(s:char, "i")
-      if char_mapping != ""
+      " break if chars exactly match mapping or if chars don't match beging of mapping anymore
+      if char_mapping != "" || mapcheck(s:char, "i") == ""
         " handle case where mapping is <esc>
         exec 'let s:char = "\'.char_mapping.'"'
         break

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1220,7 +1220,7 @@ function! s:wait_for_user_input(mode)
     while poll_count < &timeoutlen
       let c = getchar(0)
       let char_type = type(c)
-      let poll_count += 1
+      let poll_count += 1.5
       if char_type == 0 && c != 0
         let s:char .= nr2char(c)
       elseif char_type == 1 " char with more than 8 bits (as string)

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1230,7 +1230,7 @@ function! s:wait_for_user_input(mode)
       " break if chars exactly match mapping or if chars don't match beging of mapping anymore
       if char_mapping != "" || mapcheck(s:char, "i") == ""
         " handle case where mapping is <esc>
-        exec 'let s:char = "\'.char_mapping.'"'
+        exec 'let s:char = "'.substitute(char_mapping, '<', '\\<', 'g').'"'
         break
       endif
       sleep 1m


### PR DESCRIPTION
Should fix #246

Having 'imap ii <Esc>' takes 'timeoutlen' ms to print i in insert mode in Vim.
We try to emulate the same behavior using sleep 1ms 'timeoutlen' times in our plugin.
How ever there some other operations done and overhead time to take into account at each loop iteration.
For that reason, we increase our time counter by 1.5 instead of 1.