### PR TITLE
Add select_all() to select all occurence of a word, map is <c-m><c-n>

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ Install using [Pathogen], [Vundle], [Neobundle], or your favorite Vim package ma
 Requires vim 7.4 or later for full functionality.
 
 ## Quick Start
-Out of the box, all you need to know is a single key `Ctrl-n`. Pressing the key in Normal mode highlights the current word under the cursor in Visual mode and places a virtual cursor at the end of it. Pressing it again finds the next occurrence and places another virtual cursor at the end of the visual selection. If you select multiple lines in Visual mode, pressing the key puts a virtual cursor at every line and leaves you in Normal mode.
+Out of the box, all you need to know is a single key `Ctrl-n`.
+
+Pressing the key in Normal mode highlights the current word under the cursor in Visual mode and places a virtual cursor at the end of it. Pressing it again finds the next ocurrence and places another virtual cursor at the end of the visual selection. You can also directly select all occurences by pressing `Ctrl-m Ctrl-n`.
+
+If you select multiple lines in Visual mode, pressing the key puts a virtual cursor at every line and leaves you in Normal mode.
 
 After you've marked all your locations with `Ctrl-n`, you can change the visual selection with normal Vim motion commands in Visual mode. You could go to Normal mode by pressing `v` and wield your motion commands there. Single key command to switch to Insert mode such as `c` or `s` from Visual mode or `i`, `a`, `I`, `A` in Normal mode should work without any issues.
 
@@ -74,17 +78,19 @@ You can also add multiple cursors using a regular expression. The command `Multi
 **NOTE:** If at any time you have lingering cursors on screen, you can press `Ctrl-n` in Normal mode and it will remove all prior cursors before starting a new one.
 
 ## Mapping
-Out of the box, only the single key `Ctrl-n` is mapped in regular Vim's Normal mode and Visual mode to provide the functionality mentioned above. `Ctrl-n`, `Ctrl-p`, `Ctrl-x`, and `<Esc>` are mapped in the special multicursor mode once you've added at least one virtual cursor to the buffer. If you don't like the plugin taking over your favorite key bindings, you can turn off the default with
+If you don't like the plugin taking over your favorite key bindings, you can turn off the default with
 ```viml
 let g:multi_cursor_use_default_mapping=0
 
 " Default mapping
-let g:multi_cursor_start_word_key='<C-n>'
-let g:multi_cursor_start_key='g<C-n>'
-let g:multi_cursor_next_key='<C-n>'
-let g:multi_cursor_prev_key='<C-p>'
-let g:multi_cursor_skip_key='<C-x>'
-let g:multi_cursor_quit_key='<Esc>'
+let g:multi_cursor_start_word_key      = '<C-n>'
+let g:multi_cursor_select_all_word_key = '<C-m><C-n>'
+let g:multi_cursor_start_key           = 'g<C-n>'
+let g:multi_cursor_select_all_key      = 'g<C-m><C-n>'
+let g:multi_cursor_next_key            = '<C-n>'
+let g:multi_cursor_prev_key            = '<C-p>'
+let g:multi_cursor_skip_key            = '<C-x>'
+let g:multi_cursor_quit_key            = '<Esc>'
 ```
 
 By default `<C-n>` will start multicursor mode with word boundaries (behaves like `*`) and `g<C-n>` without word boundaries (behaves like `g*`).

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -283,6 +283,22 @@ function! multiple_cursors#find(start, end, pattern)
   endif
 endfunction
 
+" apply multiple_cursors#find() on the whole buffer
+function! multiple_cursors#select_all(mode, word_boundary)
+  if a:mode == 'v'
+    let a_save = @a
+    normal! gv"ay
+    let pattern = @a
+    let @a = a_save
+  elseif a:mode == 'n'
+    let pattern = expand('<cword>')
+  endif
+  if a:word_boundary == 1
+    let pattern = '\<'.pattern.'\>'
+  endif
+  call multiple_cursors#find(1, line('$'), pattern)
+endfunction
+
 "===============================================================================
 " Cursor class
 "===============================================================================

--- a/doc/multiple_cursors.txt
+++ b/doc/multiple_cursors.txt
@@ -36,11 +36,15 @@ another attempt at that.
 ==============================================================================
 2. Usage                                              *multiple-cursors-usage*
 
-Out of the box, all you need to know is a single key CTRL-N. Pressing the key
-in Normal mode highlights the current word under the cursor in Visual mode and
-places a virtual cursor at the end of it. Pressing it again finds the next
-ocurrence and places another virtual cursor at the end of the visual
-selection. If you select multiple lines in Visual mode, pressing the key puts
+Out of the box, all you need to know is a single key CTRL-N.
+
+Pressing the key in Normal mode highlights the current word under the cursor
+in Visual mode and places a virtual cursor at the end of it. Pressing it again
+finds the next ocurrence and places another virtual cursor at the end of the
+visual selection. You can also directly select all occurences by pressing
+CTRL-M CTRL-N.
+
+If you select multiple lines in Visual mode, pressing the key puts
 a virtual cursor at every line and leaves you in Normal mode.
 
 After you've marked all your locations with CTRL-N, you can change the visual
@@ -55,7 +59,7 @@ Two additional keys are also mapped:
 
 CTRL-P in Visual mode will remove the current virtual cursor and go back to
 the previous virtual cursor location. This is useful if you are trigger happy
-with Ctrl-n and accidentally went too far.
+with Ctrl-N and accidentally went too far.
 
 CTRL-X in Visual mode will remove the current virtual cursor and skip to the
 next virtual cursor location. This is useful if you don't want the current
@@ -75,40 +79,46 @@ new one.
 
 *g:multi_cursor_start_word_key* (Default: '<C-n>')
     normal:
-        - start multicursor mode with word boundary
-        - select word like `*`
+        - start multicursor mode with word boundary (like `*`)
     visual:
-        - start muticursor mode with selected word
+        - start muticursor mode with visual selection
     visual line/block:
         - start muticursor with no selection
         - cursors start on the left of the visual block
         - cannot use 'next' 'previous' and 'skip'
 
-*g:multi_cursor_start_key* (Default: 'g<C-n>')
+*g:multi_cursor_select_all_word_key* (Default: '<C-m><C-n>')
     normal:
-        - start multicursor mode without word boundary
-        - select word like `g*`
+        - select all occurences with word boundary (like `*`)
+    visual:
+        - select all occurences of visual selection
+    cannot use 'next' 'previous' and 'skip'
+
+*g:multi_cursor_start_key* (Default: 'g<C-n>')
+    like *g:multi_cursor_start_word_key* but select words like `g*`
+
+*g:multi_cursor_select_all_key* (Default: 'g<C-m><C-n>')
+    like *g:multi_cursor_select_all_word_key* but select words like `g*`
 
 *g:multi_cursor_next_key* (Default: '<C-n>')
 *g:multi_cursor_prev_key* (Default: '<C-p>')
 *g:multi_cursor_skip_key* (Default: '<C-x>')
 *g:multi_cursor_quit_key* (Default: '<Esc>')
-Out of the box, only the single key CTRL-N is mapped in regular Vim's Normal
-mode and Visual mode to provide the functionality mentioned above. CTRL-N,
-CTRL-P, CTRL-X, and <ESC> are mapped in the special multicursor mode once
-you've added at least one virtual cursor to the buffer. If you don't like the
-plugin taking over your favorite key bindings, you can turn off the default
-with >
+
+If you don't like the plugin taking over your favorite key bindings, you can
+turn off the default with >
 
     let g:multi_cursor_use_default_mapping=0
 
     " Default mapping
-    let g:multi_cursor_start_word_key='<C-n>'
-    let g:multi_cursor_start_key='g<C-n>'
-    let g:multi_cursor_next_key='<C-n>'
-    let g:multi_cursor_prev_key='<C-p>'
-    let g:multi_cursor_skip_key='<C-x>'
-    let g:multi_cursor_quit_key='<Esc>'
+    let g:multi_cursor_start_word_key      = '<C-n>'
+    let g:multi_cursor_select_all_word_key = '<C-m><C-n>'
+    let g:multi_cursor_start_key           = 'g<C-n>'
+    let g:multi_cursor_select_all_key      = 'g<C-m><C-n>'
+    let g:multi_cursor_next_key            = '<C-n>'
+    let g:multi_cursor_prev_key            = '<C-p>'
+    let g:multi_cursor_skip_key            = '<C-x>'
+    let g:multi_cursor_quit_key            = '<Esc>'
 <
 
 NOTE: Please make sure to always map something to |g:multi_cursor_quit_key|,

--- a/plugin/multiple_cursors.vim
+++ b/plugin/multiple_cursors.vim
@@ -34,12 +34,14 @@ let s:settings = {
       \ }
 
 let s:settings_if_default = {
-      \ 'quit_key': '<Esc>',
-      \ 'start_key': 'g<C-n>',
-      \ 'start_word_key': '<C-n>',
-      \ 'next_key': '<C-n>',
-      \ 'prev_key': '<C-p>',
-      \ 'skip_key': '<C-x>',
+      \ 'quit_key':            '<Esc>',
+      \ 'start_key':           'g<C-n>',
+      \ 'start_word_key':      '<C-n>',
+      \ 'next_key':            '<C-n>',
+      \ 'prev_key':            '<C-p>',
+      \ 'skip_key':            '<C-x>',
+      \ 'select_all_key':      'g<C-m><C-n>',
+      \ 'select_all_word_key': '<C-m><C-n>',
       \ }
 
 let s:default_normal_maps = {'!':1, '@':1, '=':1, 'q':1, 'r':1, 't':1, 'T':1, 'y':1, '[':1, ']':1, '\':1, 'd':1, 'f':1, 'F':1, 'g':1, '"':1, 'z':1, 'c':1, 'm':1, '<':1, '>':1}
@@ -76,6 +78,21 @@ if exists('g:multi_cursor_start_word_key')
   " In Visual mode word boundary is not used
   exec 'xnoremap <silent> '.g:multi_cursor_start_word_key.
         \' :<C-u>call multiple_cursors#new("v", 0)<CR>'
+endif
+
+if exists('g:multi_cursor_select_all_key')
+  exec 'nnoremap <silent> '.g:multi_cursor_select_all_key.
+        \' :call multiple_cursors#select_all("n", 0)<CR>'
+  exec 'xnoremap <silent> '.g:multi_cursor_select_all_key.
+        \' :<C-u>call multiple_cursors#select_all("v", 0)<CR>'
+endif
+
+if exists('g:multi_cursor_select_all_word_key')
+  exec 'nnoremap <silent> '.g:multi_cursor_select_all_word_key.
+        \' :call multiple_cursors#select_all("n", 1)<CR>'
+  " In Visual mode word boundary is not used
+  exec 'xnoremap <silent> '.g:multi_cursor_select_all_word_key.
+        \' :<C-u>call multiple_cursors#select_all("v", 0)<CR>'
 endif
 
 " Commands


### PR DESCRIPTION
Fix #151 
Add the following mappings in both **normal** and **visual**:

- ```<C-m><C-n>```: select all occurrence with word boundaries
- ```g<C-m><C-n>```: select all occurrence without word boundary

The prefix ```<C-m>``` was chosen because **m** is close from **n** and starts like **m**ultiple
The prefix ```<C-a>``` would have be better (like **a**ll) but it was already used to increment numbers.

@eapache @balta2ar , let me know what you think.
I have been using this feature for 2 days, and I must say it is extremely addictive :)