### PR TITLE
Ensure we call Multiple_cursors_after in all cases

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1262,7 +1262,7 @@ function! s:wait_for_user_input(mode)
     endwhile
   elseif s:from_mode !=# 'i' && s:char[0] ==# ":"
     call feedkeys(s:char)
-    call s:cm.reset(1, 1)
+    call s:cm.reset(1, 1, 1)
     return
   elseif s:from_mode ==# 'n' || s:from_mode =~# 'v\|V'
     while match(s:last_char(), "\\d") == 0


### PR DESCRIPTION
We were skipping it if you exited multiple cursor mode via a `:` special
command. Now we're not.

@antoinemadec I played around with just calling `s:exit()` here since that seemed to be more correct and would result in fewer inconsistencies like this, but it ended up breaking more things for some reason.