### PR TITLE
Documentation: Offer different workaround for selection=exclusive via plugin hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ g:multi_cursor_select_all_key
 #### **Q** <kbd>CTRL</kbd>+<kbd>n</kbd> doesn't seem to work in gVIM?
 **A** Try setting `set selection=inclusive` in your `~/.gvimrc`
 
+**A** Alternatively, you can just temporarily disable _exclusive_ selection whenever the plugin is active:
+```VimL
+augroup MultipleCursorsSelectionFix
+    autocmd User MultipleCursorsPre  if &selection ==# 'exclusive' | let g:multi_cursor_save_selection = &selection | set selection=inclusive | endif
+    autocmd User MultipleCursorsPost if exists('g:multi_cursor_save_selection') | let &selection = g:multi_cursor_save_selection | unlet g:multi_cursor_save_selection | endif
+augroup END
+```
+
 #### **Q** is it also working on Mac?
 **A** On Mac OS, [MacVim](https://code.google.com/p/macvim/) is known to work.
 


### PR DESCRIPTION
This is less intrusive that completely switching the 'selection' option to "inclusive". The setting is there for a reason; some users actually prefer this mode! (Unfortunately, this also makes it much harder for plugins to behave correctly.)

 &lt;SoapBox&gt;
Of course, ideally the plugin would "just work" with any `'selection'` value. I tried to patch that in, but it's not trivial, and I think intricate knowledge of all the stored positions is needed; something which you as the author surely have, but I don't. Actually accounting for exclusive selections is easy; usually just a `:normal! h` to correct the cursor position, or in the worst case subtracting the byte length of the last captured character from the end column. I guess the majority of the Vim user base does not change this option; however, there is a minority that does (including me). So, if you've ever been on the fence whether to add support for this, please reconsider; I'd be happy to test any patch!
