### PR TITLE
Readme: Typo fix "muticursor"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ call plug#end()
     * next:         `<C-n>` add a new _virtual cursor + selection_ on the next match
     * skip:         `<C-x>` skip the next match
     * prev:         `<C-p>` remove current _virtual cursor + selection_ and go back on previous match
-  * select all:     `<A-n>` start muticursor and directly select all matches
+  * select all:     `<A-n>` start multicursor and directly select all matches
 
 You can now change the _virtual cursors + selection_ with **visual mode** commands.
 For instance: `c`, `s`, `I`, `A` work without any issues.


### PR DESCRIPTION
Small typo fixed in the `README.md` file.