### PR TITLE
Remove literal `<Esc>` and let `:normal` cancel the command implicitly

### DIFF
--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1285,7 +1285,7 @@ function! s:wait_for_user_input(mode)
   call s:start_latency_measure()
 
   " Clears any echoes we might've added
-  normal! :<Esc>
+  normal! :
 
   " add chars to s:char if it start like a special/quit key
   let is_special_key = 0


### PR DESCRIPTION
The `<Esc>` ends up not cancelling command-line mode. Instead, it just inserts a literal `:<Esc>` command that doesn't really exist.

This actually works because, as [`:help :normal`](https://vimhelp.org/various.txt.html#%3Anormal) says:

> `{commands}` should be a complete command.  If `{commands}` does not finish a command, the last one will be aborted as if `<Esc>` or `<C-C>` was typed. [...] A `:` command must be completed as well.

So while fixing this with `exec "normal! :\<Esc>"` would have been possible (and this fix sequence has been employed elsewhere in this file, where `<Esc>` is actually necessary), it's not really necessary here since an implicit `<Esc>` will be added by `:normal` implicitly.
