### PR TITLE
Fix Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
-sudo: false
+os: linux
+dist: bionic
 language: ruby
 
 addons:
   apt:
     packages:
       - vim-gtk
+      - xvfb
 
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+script:
+  - xvfb-run bundle exec rake


### PR DESCRIPTION
Use the `xvfb-run` command to run the `bundle exec rake` script directly, rather than trying to start the Xvfb server on an explicit `$DISPLAY`, which was failing under Travis-CI.

Update to use a recent Ubuntu 18.04 distribution (bionic).

Fix other warnings from Travis-CI (such as missing `os: linux` and also `sudo:` attribute being deprecated now.)

Tested on [my fork](https://travis-ci.org/github/filbranden/vim-multiple-cursors/builds/688574776) (this Travis-CI build also includes PR #310)